### PR TITLE
Don't send hits when app is in background

### DIFF
--- a/ATInternetTracker/Sources/Configuration.swift
+++ b/ATInternetTracker/Sources/Configuration.swift
@@ -101,6 +101,8 @@ public class TrackerConfigurationKeys: NSObject {
     public static let AutoTracking = "enableAutoTracking"
     /// autoTrackerToken
     public static let AutoTrackerToken = "autoTrackerToken"
+    /// send only when host App is in state "active" (foreground)
+    public static let SendOnlyWhenAppActive = "sendOnlyWhenAppActive"
 }
 
 /// Tracker configuraiton

--- a/ATInternetTracker/Sources/DefaultConfiguration~ipad.plist
+++ b/ATInternetTracker/Sources/DefaultConfiguration~ipad.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>sendOnlyWhenAppActive</key>
+	<string>false</string>
 	<key>atEnv</key>
 	<string>prod</string>
 	<key>enableAutoTracking</key>

--- a/ATInternetTracker/Sources/DefaultConfiguration~iphone.plist
+++ b/ATInternetTracker/Sources/DefaultConfiguration~iphone.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>sendOnlyWhenAppActive</key>
+	<string>false</string>
 	<key>atEnv</key>
 	<string>prod</string>
 	<key>autoTrackerToken</key>

--- a/ATInternetTracker/Sources/DefaultConfiguration~ipod.plist
+++ b/ATInternetTracker/Sources/DefaultConfiguration~ipod.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>sendOnlyWhenAppActive</key>
+	<string>false</string>
 	<key>atEnv</key>
 	<string>prod</string>
 	<key>autoTrackerToken</key>

--- a/ATInternetTracker/Sources/Sender.swift
+++ b/ATInternetTracker/Sources/Sender.swift
@@ -95,7 +95,8 @@ class Sender: Operation {
     - parameter a: callback to indicate whether hit was sent successfully or not
     */
     func sendWithCompletionHandler(_ completionHandler: ((_ success: Bool) -> Void)?) {
-        if (TechnicalContext.doNotTrack) {
+        // Don't send hits if DNT is enabled or the app is not in the foreground
+        if TechnicalContext.doNotTrack || !TechnicalContext.applicationIsActive {
             completionHandler?(false)
             return
         }

--- a/ATInternetTracker/Sources/Sender.swift
+++ b/ATInternetTracker/Sources/Sender.swift
@@ -96,8 +96,9 @@ class Sender: Operation {
     */
     func sendWithCompletionHandler(_ completionHandler: ((_ success: Bool) -> Void)?) {
         // Don't send hits if DNT is enabled or the app is not in the foreground
-        // and background tasks are not enabled
-        if TechnicalContext.doNotTrack || (TechnicalContext.applicationIsActive && !tracker.backgroundTaskEnabled) {
+        // and background send is not enabled
+        
+        if TechnicalContext.doNotTrack || (!TechnicalContext.applicationIsActive && tracker.sendOnlyWhenAppActive) {
             completionHandler?(false)
             return
         }
@@ -346,5 +347,11 @@ extension Tracker {
             else { return false }
         
         return enableBackgroundTask.lowercased() == "true"
+    }
+    var sendOnlyWhenAppActive: Bool {
+        guard let enableSendOnlyWhenAppActive = configuration.parameters["sendOnlyWhenAppActive"]
+            else { return false }
+        
+        return enableSendOnlyWhenAppActive.lowercased() == "true"
     }
 }

--- a/ATInternetTracker/Sources/TechnicalContext.swift
+++ b/ATInternetTracker/Sources/TechnicalContext.swift
@@ -102,9 +102,7 @@ class TechnicalContext: NSObject {
         }
     }
     
-    class var applicationIsActive: Bool {
-        return UIApplication.shared.applicationState == .active
-    }
+    static var applicationIsActive: Bool = false
     
     /// Unique user id
     class func userId(_ identifier: String?) -> String {

--- a/ATInternetTracker/Sources/TechnicalContext.swift
+++ b/ATInternetTracker/Sources/TechnicalContext.swift
@@ -102,6 +102,10 @@ class TechnicalContext: NSObject {
         }
     }
     
+    class var applicationIsActive: Bool {
+        return UIApplication.shared.applicationState == .active
+    }
+    
     /// Unique user id
     class func userId(_ identifier: String?) -> String {
         

--- a/ATInternetTracker/Sources/Tracker.swift
+++ b/ATInternetTracker/Sources/Tracker.swift
@@ -656,6 +656,7 @@ public class Tracker: NSObject {
      should save the timestamp to know if we have to start a new session on the next launch
      */
     @objc func applicationDidEnterBackground() {
+        TechnicalContext.applicationIsActive = false
         LifeCycle.applicationDidEnterBackground()
     }
     
@@ -664,6 +665,7 @@ public class Tracker: NSObject {
      Should create a new SessionId if necessary
      */
     @objc func applicationActive() {
+        TechnicalContext.applicationIsActive = true
         LifeCycle.applicationActive(self.configuration.parameters)
     }
     
@@ -857,6 +859,16 @@ public class Tracker: NSObject {
     ///   - completionHandler: called when the operation has been done
     @objc public func setBackgroundTaskEnabled(_ enabled: Bool, sync: Bool = false, completionHandler: ((_ isSet: Bool) -> Void)?) {
         setConfig(TrackerConfigurationKeys.EnableBackgroundTask, value: String(enabled), sync: sync, completionHandler: completionHandler)
+    }
+    
+    /// Ensures that all hits are sent only in foreground if set to true. (default: false)
+    ///
+    /// - Parameters:
+    ///   - enabled: /
+    ///   - sync: perform the operation synchronously (optional, default: false)
+    ///   - completionHandler: called when the operation has been done
+    @objc public func setSendOnlyWhenAppActive(_ enabled: Bool, sync: Bool = false, completionHandler: ((_ isSet: Bool) -> Void)?) {
+        setConfig(TrackerConfigurationKeys.SendOnlyWhenAppActive, value: String(enabled), sync: sync, completionHandler: completionHandler)
     }
     
     /// Set new pixel path

--- a/ATInternetTracker/Tests/BuilderTests.swift
+++ b/ATInternetTracker/Tests/BuilderTests.swift
@@ -69,7 +69,7 @@ class BuilderTests: XCTestCase, TrackerDelegate {
     }
     
     var tracker = Tracker()
-    let configuration = ["log":"logp", "logSSL":"logs", "domain":"xiti.com", "pixelPath":"/hit.xiti", "site":"549808", "secure":"false", "identifier":"uuid"]
+    let configuration = ["log":"logp", "logSSL":"logs", "domain":"xiti.com", "pixelPath":"/hit.xiti", "site":"549808", "secure":"false", "identifier":"uuid", "sendOnlyWhenAppActive":"false"]
     
     override func setUp() {
         super.setUp()

--- a/ATInternetTracker/Tests/ConfigurationTests.swift
+++ b/ATInternetTracker/Tests/ConfigurationTests.swift
@@ -36,9 +36,9 @@ import XCTest
 class ConfigurationTests: XCTestCase {
     
     // Configuration définie
-    let myConf = ["log":"customlog", "logSSL":"customlogs", "domain":"customdomain", "pixelPath":"custompixelpath","site":"customsite", "secure":"customsecure", "identifier":"customidentifier", "plugins":"", "enableBackgroundTask":"false", "storage":"never", "hashUserId":"false", "persistIdentifiedVisitor":"true","sessionBackgroundDuration":"60", "campaignLastPersistence": "true", "campaignLifetime": "30","downloadSource":"ext", "autoTrackerToken": "", "enableAutoTracking": "false", "atEnv":"prod"]
+    let myConf = ["log":"customlog", "logSSL":"customlogs", "domain":"customdomain", "pixelPath":"custompixelpath","site":"customsite", "secure":"customsecure", "identifier":"customidentifier", "plugins":"", "enableBackgroundTask":"false", "storage":"never", "hashUserId":"false", "persistIdentifiedVisitor":"true","sessionBackgroundDuration":"60", "campaignLastPersistence": "true", "campaignLifetime": "30","downloadSource":"ext", "autoTrackerToken": "", "enableAutoTracking": "false", "atEnv":"prod", "sendOnlyWhenAppActive":"false"]
     // Configuration par défaut
-    let defaultConf = ["log":"", "logSSL":"", "domain":"xiti.com", "pixelPath":"/hit.xiti", "site":"", "secure":"false", "identifier":"uuid", "plugins":"", "enableBackgroundTask":"false", "storage":"never", "hashUserId":"false", "persistIdentifiedVisitor":"true","sessionBackgroundDuration":"60", "campaignLastPersistence": "true", "campaignLifetime": "30","downloadSource":"ext", "autoTrackerToken": "", "enableAutoTracking": "false","atEnv":"prod"]
+    let defaultConf = ["log":"", "logSSL":"", "domain":"xiti.com", "pixelPath":"/hit.xiti", "site":"", "secure":"false", "identifier":"uuid", "plugins":"", "enableBackgroundTask":"false", "storage":"never", "hashUserId":"false", "persistIdentifiedVisitor":"true","sessionBackgroundDuration":"60", "campaignLastPersistence": "true", "campaignLifetime": "30","downloadSource":"ext", "autoTrackerToken": "", "enableAutoTracking": "false","atEnv":"prod", "sendOnlyWhenAppActive":"false"]
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
This PR stops the SDK from sending any hits if the app is not in `UIApplicationState.active` aka on screen and receiving events. 

This should be a sensible default since you might otherwise send hits if iOS re-renders the UI in the background without user interaction (e.g. if background refresh or background push happens).

Normally you would not want this to be tracked as a hit. 

Depending on your preference you could also add a configuration option for this behaviour. 

To validate this change:

- Set up the SDK and send a hit in `applicationDidFinishLaunching`.
- Start the app with "Launch due to a background fetch event" enabled in "Schema > Run" (Only present on devices, not simulator)

With the current `master` of the SDK you should see a hit, with the changes in this PR there should be no hits being received unless you set `enableBackgroundTask = true` in the SDK config. 