### PR TITLE
Fix for failed tracking events due to invalid URL's 

### DIFF
--- a/ATInternetTracker/Sources/Builder.swift
+++ b/ATInternetTracker/Sources/Builder.swift
@@ -464,9 +464,9 @@ class Builder: Operation {
             
             var separator = p.options?.separator ?? ","
             if let opts = p.options, opts.encode == true {
-                strValue = strValue.percentEncodedString
                 separator = opts.separator.percentEncodedString
             }
+            strValue = strValue.percentEncodedString
             
             formattedParameters.append( (p.key, (self.makeSubQuery(p.key, value: strValue), separator)) )
         }


### PR DESCRIPTION
EDIT: The root cause of this issue was caused by my implementation but I think this should still be considered. 

This addresses an issue with some query params not getting properly escaped and they cause hits to fail. An example (there are a few) would be the parameter for "os" does not get escaped and it has open and close brackets.