### PR TITLE
Fix some bug due to force unwrappe valuebefore comparing condition

### DIFF
--- a/ATAnalytics.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ATAnalytics.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ATInternetTracker/Sources/Campaign.swift
+++ b/ATInternetTracker/Sources/Campaign.swift
@@ -65,9 +65,7 @@ public class Campaign: ScreenInfo {
         if let remanentCampaign = userDefaults.value(forKey: CampaignKeys.ATCampaign.rawValue) as? String, let campaignDate = userDefaults.object(forKey: CampaignKeys.ATCampaignDate.rawValue) as? Date {
             let nbDays: Int = Tool.daysBetweenDates(campaignDate, toDate: Date())
             
-            if let campaignValue = tracker.configuration.parameters["campaignLifetime"],
-                let campaignIntValue = Int(campaignValue),
-                (nbDays > campaignIntValue) {
+            if let campaignValue = tracker.configuration.parameters["campaignLifetime"], let campaignIntValue = Int(campaignValue), nbDays > campaignIntValue {
                 userDefaults.removeObject(forKey: CampaignKeys.ATCampaign.rawValue)
             } else {
                 let remanent = remanentCampaign

--- a/ATInternetTracker/Sources/Campaign.swift
+++ b/ATInternetTracker/Sources/Campaign.swift
@@ -65,7 +65,9 @@ public class Campaign: ScreenInfo {
         if let remanentCampaign = userDefaults.value(forKey: CampaignKeys.ATCampaign.rawValue) as? String, let campaignDate = userDefaults.object(forKey: CampaignKeys.ATCampaignDate.rawValue) as? Date {
             let nbDays: Int = Tool.daysBetweenDates(campaignDate, toDate: Date())
             
-            if(nbDays > Int(tracker.configuration.parameters["campaignLifetime"]!)!) {
+            if let campaignValue = tracker.configuration.parameters["campaignLifetime"],
+                let campaignIntValue = Int(campaignValue),
+                (nbDays > campaignIntValue) {
                 userDefaults.removeObject(forKey: CampaignKeys.ATCampaign.rawValue)
             } else {
                 let remanent = remanentCampaign


### PR DESCRIPTION
We have a bug that often comes from setting a different value than "Int", and as we force unwrap the condition before testing it, it crashes systematically.

For the moment it's a small fix, we could later add a propagation error and manage the different kinds of crashes.