### PR TITLE
fix: Replace `subscript`pattern by calling `setValue`

### DIFF
--- a/ATInternetTracker/Sources/Tracker.swift
+++ b/ATInternetTracker/Sources/Tracker.swift
@@ -818,7 +818,7 @@ public class Tracker: NSObject {
             
             newValues.append(value)
             param.values = newValues
-            buffer.persistentParameters[key] = param
+            buffer.persistentParameters.setValue(value: param, forKeyPath: key)
         } else {
             if options.append {
                 if let existingParam = buffer.volatileParameters[key] {
@@ -830,7 +830,7 @@ public class Tracker: NSObject {
             }
             newValues.append(value)
             param.values = newValues
-            buffer.volatileParameters[key] = param
+            buffer.volatileParameters.setValue(value: param, forKeyPath: key)
         }
     }
     


### PR DESCRIPTION
There is a crash that occurs in iOS 11 (iPhone 6S) doing :
```swift
let tracker = ATInternet.sharedInstance.tracker(Constants.trackerName, configuration: configuration)
tracker.context.level2 = Constants.iosLevel2Id
```
<img width="1431" alt="Capture d’écran 2020-09-28 à 17 38 56" src="https://user-images.githubusercontent.com/11225721/94819974-34f64d00-0400-11eb-8d31-acc0579c32df.png">

Here, `key` contains **s2** as value. By doing, `po buffer.persistentParameters[key]`, it returns `nil`.
I don't really know the reason for this, but calling `setValue(value :, forKeyPath :)` instead of the `subscript` method, there are no more crashes
