### PR TITLE
[Feat] Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ xcuserdata/
 !*.xcodeproj/project.pbxproj
 docs/
 *.swp
+.swiftpm/

--- a/ATInternetTracker/AppExtension
+++ b/ATInternetTracker/AppExtension
@@ -1,0 +1,1 @@
+Sources

--- a/ATInternetTracker/ObjC/Crash.m
+++ b/ATInternetTracker/ObjC/Crash.m
@@ -1,0 +1,1 @@
+../Sources/Crash.m

--- a/ATInternetTracker/ObjC/Hash.m
+++ b/ATInternetTracker/ObjC/Hash.m
@@ -1,0 +1,1 @@
+../Sources/Hash.m

--- a/ATInternetTracker/ObjC/include/Crash.h
+++ b/ATInternetTracker/ObjC/include/Crash.h
@@ -1,0 +1,1 @@
+../../Sources/Crash.h

--- a/ATInternetTracker/ObjC/include/Hash.h
+++ b/ATInternetTracker/ObjC/include/Hash.h
@@ -1,0 +1,1 @@
+../../Sources/Hash.h

--- a/ATInternetTracker/Sources/ATBundle.swift
+++ b/ATInternetTracker/Sources/ATBundle.swift
@@ -8,11 +8,23 @@
 import Foundation
 
 func pathFor(asset: String) -> String? {
-    let bundlePath = Bundle(for: Tracker.self).path(forResource: "TrackerBundle", ofType: "bundle")
+    let bundlePath = Bundle.tracker.path(forResource: "TrackerBundle", ofType: "bundle")
     if let bp = bundlePath {
         let bundle = Bundle(path: bp)
         return bundle?.path(forResource: asset, ofType: "png")
     } else {
         return nil
     }
+}
+
+extension Bundle {
+
+    static var tracker: Bundle {
+        #if SWIFT_PACKAGE
+        return .module
+        #else
+        return Bundle(for: Tracker.self)
+        #endif
+    }
+
 }

--- a/ATInternetTracker/Sources/ATReachability.swift
+++ b/ATInternetTracker/Sources/ATReachability.swift
@@ -24,6 +24,9 @@
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
  */
+
+#if !os(watchOS)
+
 #if canImport(SystemConfiguration)
 import SystemConfiguration
 #endif
@@ -372,3 +375,4 @@ public class ATReachability: NSObject {
         whenUnreachable = nil
     }
 }
+#endif

--- a/ATInternetTracker/Sources/BackgroundTask.swift
+++ b/ATInternetTracker/Sources/BackgroundTask.swift
@@ -26,6 +26,9 @@
 //  BackgroundTaskManager.swift
 //  Tracker
 //
+
+#if !os(watchOS)
+
 import Foundation
 #if canImport(UIKit)
 import UIKit
@@ -138,3 +141,5 @@ public class BackgroundTask: NSObject {
         }
     }
 }
+
+#endif

--- a/ATInternetTracker/Sources/Cart.swift
+++ b/ATInternetTracker/Sources/Cart.swift
@@ -30,6 +30,7 @@ SOFTWARE.
 //  Tracker
 //
 
+import Foundation
 
 /// Wrapper class to manage your cart
 public class Cart: BusinessObject {

--- a/ATInternetTracker/Sources/Configuration.swift
+++ b/ATInternetTracker/Sources/Configuration.swift
@@ -183,12 +183,7 @@ class Configuration: NSObject {
     */
     override init() {
         super.init()
-        guard let selfObject = object_getClass(self) else {
-            print("Default Tracker Configuration not found")
-            return
-        }
-        let bundle = Bundle(for: selfObject)
-        let path = bundle.path(forResource: "DefaultConfiguration", ofType: "plist")
+        let path = Bundle.tracker.path(forResource: "DefaultConfiguration", ofType: "plist")
         if let optPath = path {
             let defaultConf = NSDictionary(contentsOfFile: optPath)
             if let optDefaultConf = defaultConf as? [String: String] {

--- a/ATInternetTracker/Sources/Debugger.swift
+++ b/ATInternetTracker/Sources/Debugger.swift
@@ -31,7 +31,7 @@
 import UIKit
 #endif
 
-#if os(iOS) && !AT_EXTENSION
+#if os(iOS) && !AT_EXTENSION && !os(watchOS)
 class DebuggerButton: UIButton {}
 class DebuggerView: UIView {}
 
@@ -648,7 +648,7 @@ internal class Debugger: NSObject {
         rowView.addSubview(hitTypeView)
         
         /******* ICON ********/
-        iconView.image = UIImage(named: event.type, in: Bundle(for: Tracker.self), compatibleWith: nil)
+        iconView.image = UIImage(named: event.type, in: Bundle.tracker, compatibleWith: nil)
         
         rowView.addConstraint(NSLayoutConstraint(item: iconView,
             attribute: .left,

--- a/ATInternetTracker/Sources/Dispatcher.swift
+++ b/ATInternetTracker/Sources/Dispatcher.swift
@@ -32,6 +32,10 @@ SOFTWARE.
 
 import Foundation
 
+#if canImport(TrackerObjc)
+import TrackerObjc
+#endif
+
 class Dispatcher: NSObject {
     
     /// Tracker instance

--- a/ATInternetTracker/Sources/Screen.swift
+++ b/ATInternetTracker/Sources/Screen.swift
@@ -32,6 +32,9 @@ SOFTWARE.
 
 import Foundation
 
+#if canImport(TrackerObjc)
+import TrackerObjc
+#endif
 
 /// Business object type for screen tracking. Used only for specific case.
 public class ScreenInfo: BusinessObject {

--- a/ATInternetTracker/Sources/StringExtension.swift
+++ b/ATInternetTracker/Sources/StringExtension.swift
@@ -32,6 +32,10 @@ SOFTWARE.
 
 import Foundation
 
+#if canImport(TrackerObjc)
+import TrackerObjc
+#endif
+
 /// Properties for extending String object
 extension String {    
     /// Returns a percent encoded string

--- a/ATInternetTracker/Sources/Tracker.swift
+++ b/ATInternetTracker/Sources/Tracker.swift
@@ -32,6 +32,10 @@
 
 import Foundation
 
+#if canImport(TrackerObjc)
+import TrackerObjc
+#endif
+
 #if canImport(UIKit)
 import UIKit
 #endif

--- a/ATInternetTracker/Tests/TechnicalContextTests.swift
+++ b/ATInternetTracker/Tests/TechnicalContextTests.swift
@@ -52,7 +52,7 @@ class TechnicalContextTests: XCTestCase {
     }
     
     func testVersion() {
-        let testBundle = Bundle(for: Tracker.self)
+        let testBundle = Bundle.tracker
         if let url = testBundle.url(forResource: "Info", withExtension: "plist"),
             let myDict = NSDictionary(contentsOf: url) as? [String : Any] {
             let v = TechnicalContext.sdkVersion

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,72 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "atinternet-apple-sdk",
+    platforms: [.iOS(.v10), .tvOS(.v10), .watchOS(.v3)],
+    products: [
+        .library(name: "Tracker", targets: ["Tracker"]),
+        .library(name: "TrackerExtension", targets: ["TrackerExtension"]),
+    ],
+    targets: [
+        .target(
+            name: "Tracker",
+            dependencies: ["TrackerObjc"],
+            path: "ATInternetTracker/Sources",
+            exclude: [
+                "Hash.m",
+                "Crash.m",
+                "Info-iOS.plist",
+                "Info-iOS-Extension.plist",
+                "Info-tvOS.plist",
+                "Info-watchOS.plist",
+                "referential.json",
+                "Tracker.h",
+                "TrackerExtension.h",
+                "TrackerTests-Bridging-Header.h",
+                "tvOSTracker.h",
+                "watchOSTracker.h",
+            ],
+            resources: [
+                .copy("TrackerBundle.bundle"),
+                .copy("DefaultConfiguration.plist"),
+                .copy("DefaultConfiguration~ipad.plist"),
+                .copy("DefaultConfiguration~iphone.plist"),
+                .copy("DefaultConfiguration~ipod.plist"),
+            ]),
+        .target(
+            name: "TrackerExtension",
+            dependencies: ["TrackerObjc"],
+            path: "ATInternetTracker/AppExtension",
+            exclude: [
+                "Hash.m",
+                "Crash.m",
+                "Info-iOS.plist",
+                "Info-iOS-Extension.plist",
+                "Info-tvOS.plist",
+                "Info-watchOS.plist",
+                "referential.json",
+                "BackgroundTask.swift",
+                "Debugger.swift",
+                "Tracker.h",
+                "TrackerExtension.h",
+                "TrackerTests-Bridging-Header.h",
+                "tvOSTracker.h",
+                "watchOSTracker.h",
+            ],
+            resources: [
+                .copy("TrackerBundle.bundle"),
+                .copy("DefaultConfiguration.plist"),
+                .copy("DefaultConfiguration~ipad.plist"),
+                .copy("DefaultConfiguration~iphone.plist"),
+                .copy("DefaultConfiguration~ipod.plist"),
+            ],
+            swiftSettings: [.define("AT_EXTENSION")]),
+        .target(
+            name: "TrackerObjc",
+            path: "ATInternetTracker/Objc"),
+    ]
+)
+

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "atinternet-apple-sdk",
+    name: "ATInternet",
     platforms: [.iOS(.v10), .tvOS(.v10), .watchOS(.v3)],
     products: [
         .library(name: "Tracker", targets: ["Tracker"]),

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Carthage is an alternative to **Cocoapods**. It’s a simple dependency manager 
 
 https://developers.atinternet-solutions.com/apple-universal-fr/bien-commencer-apple-universal-fr/integration-de-la-bibliotheque-swift-apple-universal-fr/#utilisation-de-carthage_7
 
+### Installation with Swift Package Manager
+
+  - In your Xcode project, select *File* > *Swift Packages* > *Add Package Dependency...*
+  - In the URL field, paste *https://github.com/at-internet/atinternet-apple-sdk.git* and select *Next*
+  - Select the update rule: "Up to next major" from the current version
+  - Add the product *Tracker* to your app targets (iOS, watchOS, tvOS)
+  - Add the product *TrackerExtension* to your app extension targets
+
 ## Integration samples
 ### Tracker
 ```swift


### PR DESCRIPTION
Add support for integrating ATInternet using Swift Package Manager (SPM).

Same as #84 but I was able to avoid the caveats:
- Compatible with iOS 10+, tvOS 10+, watchOS 3+, app extensions
- No changes in functionality

Tested on an iOS app with the SDK debugger. The default configuration and resource bundle are loaded, and hits are sent.

### TODO

Test on tvOS, watchOS, app extension.

### Changes for app developers

(only if using SPM) Apps using the SDK in an app extension will have to use `import TrackerExtension` instead of `import Tracker`.

### Detail of changes

- Add Package.swift with 2 products (Tracker, TrackerExtension) and 3 targets (Tracker, TrackerExtension, TrackerObjC)
- Use symbolic links to be able to have 3 targets without reorganizing the existing source code
- Add a helper extension method to locate the SDK bundle, use it instead of `Bundle(for: Tracker.self)`:
```
extension Bundle {

    static var tracker: Bundle {
        #if SWIFT_PACKAGE
        return .module
        #else
        return Bundle(for: Tracker.self)
        #endif
    }

}
```

- Add a conditional wrapper around ATReachability, BackgroundTask, Debugger to exclude them from watchOS apps.
- Add `import Foundation` when required by the compiler
- Import the Objective-C module only if building with SPM:
```
#if canImport(TrackerObjc)
import TrackerObjc
#endif
```
