### PR TITLE
Catches iOS apps run on mac in TechnicalContext.model

### DIFF
--- a/ATInternetTracker/Sources/TechnicalContext.swift
+++ b/ATInternetTracker/Sources/TechnicalContext.swift
@@ -316,6 +316,9 @@ class TechnicalContext: NSObject {
     
     class var model: String {
         if let simulatorModelIdentifier = ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] { return simulatorModelIdentifier }
+        if #available(iOS 14.0, *), ProcessInfo().isiOSAppOnMac {
+            return "iOSAppOnMac"
+        }
         var sysinfo = utsname()
         uname(&sysinfo)
         return String(bytes: Data(bytes: &sysinfo.machine, count: Int(_SYS_NAMELEN)), encoding: .ascii)?.trimmingCharacters(in: .controlCharacters) ?? ""


### PR DESCRIPTION
Proposes solution for #113 by checking, whether the app is being run on a mac as an iPad app. Currently the utsname() call always returns iPad8,6.