### PR TITLE
Restore Xcode 11 support & other fixes

### DIFF
--- a/ATInternetTracker/Sources/Crypt.swift
+++ b/ATInternetTracker/Sources/Crypt.swift
@@ -53,6 +53,7 @@ class Crypt: NSObject {
             return data
         }
         
+        #if canImport(CryptoKit)
         #if os(iOS) && !AT_EXTENSION
         if #available(iOS 13.0, *) {
             return encryption(data: data)
@@ -65,6 +66,7 @@ class Crypt: NSObject {
         if #available(tvOS 13.0, *) {
             return encryption(data: data)
         }
+        #endif
         #endif
         
         /// if force, we don't use original data
@@ -72,6 +74,7 @@ class Crypt: NSObject {
     }
     
     func decrypt(data: String) -> String? {
+        #if canImport(CryptoKit)
         #if os(iOS) && !AT_EXTENSION
         if #available(iOS 13.0, *) {
             return decryption(data: data)
@@ -85,10 +88,12 @@ class Crypt: NSObject {
             return decryption(data: data)
         }
         #endif
+        #endif
         
         return data
     }
     
+    #if canImport(CryptoKit)
     @available(iOS 13.0, *)
     @available(tvOS 13.0, *)
     @available(watchOS 6, *)
@@ -103,7 +108,9 @@ class Crypt: NSObject {
         
         return sealData.base64EncodedString()
     }
+    #endif
     
+    #if canImport(CryptoKit)
     @available(iOS 13.0, *)
     @available(tvOS 13.0, *)
     @available(watchOS 6, *)
@@ -123,7 +130,9 @@ class Crypt: NSObject {
         }
         catch { return data }
     }
+    #endif
     
+    #if canImport(CryptoKit)
     @available(iOS 13.0, *)
     @available(tvOS 13.0, *)
     @available(watchOS 6, *)
@@ -152,8 +161,10 @@ class Crypt: NSObject {
         _ = SecItemAdd(query as CFDictionary, nil)
         return key
     }
+    #endif
 }
 
+#if canImport(CryptoKit)
 @available(iOS 13.0, *)
 @available(tvOS 13.0, *)
 @available(watchOS 6, *)
@@ -172,7 +183,9 @@ extension SymmetricKey: CustomStringConvertible {
         }
     }
 }
+#endif
 
+#if canImport(CryptoKit)
 @available(iOS 13.0, *)
 @available(tvOS 13.0, *)
 @available(watchOS 6, *)
@@ -213,3 +226,4 @@ struct SymmetricKeyStore {
         return nil
     }
 }
+#endif

--- a/ATInternetTracker/Sources/Privacy.swift
+++ b/ATInternetTracker/Sources/Privacy.swift
@@ -230,7 +230,7 @@ public class Privacy: NSObject {
         }
         clearStorageFromVisitorMode(visitorMode)
         _ = storeData(StorageFeature.privacy, pairs:(PrivacyKeys.PrivacyMode.rawValue, visitorMode),
-                  (PrivacyKeys.PrivacyModeExpirationTimestamp.rawValue, Int64(Date().timeIntervalSince1970 * 1000) + Int64(duration * 86400000)),
+                  (PrivacyKeys.PrivacyModeExpirationTimestamp.rawValue, Int64(Date().timeIntervalSince1970 * 1000) + Int64(duration) * 86400000),
                   (PrivacyKeys.PrivacyVisitorConsent.rawValue, visitorConsent),
                   (PrivacyKeys.PrivacyUserId.rawValue, customUserId))
         

--- a/ATInternetTracker/Sources/Sender.swift
+++ b/ATInternetTracker/Sources/Sender.swift
@@ -184,7 +184,6 @@ class Sender: Operation {
                     sessionConfig.requestCachePolicy = NSURLRequest.CachePolicy.reloadIgnoringLocalCacheData
                     let session = URLSession(configuration: sessionConfig)
                     var request = URLRequest(url: optURL, cachePolicy: NSURLRequest.CachePolicy.reloadIgnoringLocalCacheData, timeoutInterval: 30)
-                    request.networkServiceType = NSURLRequest.NetworkServiceType.background
                     
                     if self.tracker.userAgent != "" {
                         request.setValue(self.tracker.userAgent, forHTTPHeaderField: "User-Agent")

--- a/ATInternetTracker/Sources/TechnicalContext.swift
+++ b/ATInternetTracker/Sources/TechnicalContext.swift
@@ -558,9 +558,11 @@ class TechnicalContext: NSObject {
                     if let rt = radioType {
                         if #available(iOS 14.1, *) {
                             // These radio types are not available in iOS 14.0 and 14.0.1 (causes crashes) although it seems like they are
+                            #if swift(>=5.3)
                             if rt == CTRadioAccessTechnologyNRNSA || rt == CTRadioAccessTechnologyNR {
                                 return ConnexionType.fiveg
                             }
+                            #endif
                         }
                         switch(rt) {
                         case CTRadioAccessTechnologyGPRS:
@@ -585,6 +587,10 @@ class TechnicalContext: NSObject {
                             return ConnexionType.threegplus
                         case CTRadioAccessTechnologyLTE:
                             return ConnexionType.fourg
+                        case "CTRadioAccessTechnologyNRNSA":
+                            return ConnexionType.fiveg
+                        case "CTRadioAccessTechnologyNR":
+                            return ConnexionType.fiveg
                         default:
                             return ConnexionType.unknown
                         }

--- a/ATInternetTracker/Sources/Tracker.swift
+++ b/ATInternetTracker/Sources/Tracker.swift
@@ -1501,7 +1501,6 @@ class TrackerQueue: NSObject {
         var queue = OperationQueue()
         queue.name = "TrackerQueue"
         queue.maxConcurrentOperationCount = 1
-        queue.qualityOfService = QualityOfService.background
         return queue
     }()
 }


### PR DESCRIPTION
## Description

This pull request contains various fixes that we had to make to the version 2.23.0 of SDK before releasing our apps last week. Please consider adding them to the main repository so that we can use it again instead of our fork (which will inevitably diverge).
 - Add an `#if swift(>=5.3)` condition around Core Telephony constants new in the Xcode 12 SDK so that this project still compiles with Xcode 11.
 - Add an `#if canImport(CryptoKit)` around all uses of the CryptoKit framework because it appears to be unavailable at compile time when targeting a 32 bits platform on Xcode 11 (this can be reproduced by compiling for a "Generic iOS Device").
 - Fix an integer overflow crash that happens on 32 bits platforms where `Int` is a 32 bits integer (whereas `Int` is a 64 bits integer on 64 bits platforms).
 - Improve fetching of the user agent using `WKWebView`. There is now a maximum timeout on the semaphore, and the webview is added (hidden) to the main window when possible to make sure Javascript execution is not paused indefinitely.
 - Remove the `.background` quality of service on the network queue because operation and dispatch queues with this qos can be paused indefinitely by the system in some conditions (see https://github.com/AFNetworking/AFNetworking/issues/4223 for example).
 - Remove the `.background` network service type on the network requests because analytics tracking is not a background download and should not use this type of service. This kind of service could be delayed for long periods of time by the system, which is not what we want here.

## Going further

By digging around in this SDK I have seen some parts that could really be improved. Mainly :
 - Use of `DispatchSemaphore` to synchronize intrinsically asynchronous operations should be avoid at all costs. This will block a dispatch queue and a thread for no reason and consume resources unnecessarily. This is especially true for network requests.
 - Creating a new `URLSession` for each request and destroying it afterwards is not how `URLSession` is designed to be used. It consumes ressources unnecessarily and prevents the system from doing several optimisations, mainly : keeping the HTTP connexion open and reusing it for several requests. But more broadly, most of the performance improvements that HTTP/2 has to offer will be unavailable. Instead a single `URLSession` should be created at app launch and reused for all requests. Also, if there is no need for specific customization, use the `.shared` session (or even better, let clients of the SDK provide their own session).
 - Although this PR improves it, using a headless `WKWebview` simply to obtain the user agent should actually be avoided. It consumes a lot of ressources on initialization and slows down app launch. If really necessary, a user agent could easily be constructed natively without the use of a webview (see what [Alamofire](https://github.com/Alamofire/Alamofire/blob/5a625bcaa13a2919b67b67faf0a877eabb5f3ed2/Source/HTTPHeaders.swift#L367-L414) does for example).
