### PR TITLE
fix/ios-12-crash-unused-protocol: removed unused protocol

### DIFF
--- a/ATInternetTracker/Sources/Crypt.swift
+++ b/ATInternetTracker/Sources/Crypt.swift
@@ -168,7 +168,7 @@ class Crypt: NSObject {
 @available(iOS 13.0, *)
 @available(tvOS 13.0, *)
 @available(watchOS 6, *)
-extension SymmetricKey: CustomStringConvertible {
+extension SymmetricKey {
     
     public var description: String {
         return self.rawRepresentation.withUnsafeBytes { bytes in


### PR DESCRIPTION
Closes https://github.com/at-internet/atinternet-apple-sdk/issues/120

Hi there,

As mentioned in the issue,  an unused protocol seems to cause a crash in the following conditions:

- The app integrates ATInternet (either through CocoaPods or manually)
- The app uses Objective-C as main language
- The app is running on iOS 12 or lower
- The app integrates a framework that attempts to parse JSON data into a Swift custom type that has properties that the JSON data doesn't (or are set to null).

![image](https://user-images.githubusercontent.com/15191025/127526576-6cebb12e-f228-4a4c-b514-79c907f0c2a0.png)

Removing the unused protocol fixes the crash.

This issue and the solution I'm proposing is similar to what is described in here https://stackoverflow.com/a/59338381

The issue can be reproduced in this project:
[ATInternetSampleApp.zip](https://github.com/at-internet/atinternet-apple-sdk/files/6901956/ATInternetSampleApp.zip)

Please let me know if more information is needed.

Cheers,

Felipe