### PR TITLE
Remove platform specification for app extension subspec

### DIFF
--- a/ATInternet-Apple-SDK-AppExtension.podspec
+++ b/ATInternet-Apple-SDK-AppExtension.podspec
@@ -10,6 +10,8 @@ Pod::Spec.new do |s|
 	s.source = { :git => "https://github.com/at-internet/atinternet-apple-sdk.git", :tag => s.version}
 	s.module_name = 'TrackerAppExtension'
 	s.ios.deployment_target	= '10.0'
+	s.tvos.deployment_target = '10.0'
+	s.watchos.deployment_target = '3.0'
 	s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
 	s.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 	s.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]

--- a/ATInternet-Apple-SDK-AppExtension.podspec
+++ b/ATInternet-Apple-SDK-AppExtension.podspec
@@ -13,6 +13,5 @@ Pod::Spec.new do |s|
 	s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
 	s.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 	s.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
-	s.platform = :ios, "10.0"
 	s.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
 end

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -23,7 +23,6 @@ Pod::Spec.new do |s|
         appExt.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
         appExt.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
         appExt.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
-        appExt.platform = :ios
         appExt.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
 	end
 


### PR DESCRIPTION
In order to allow other types of app extension, we need to remove the platform specifier form the subspec. It allow this dependency to be referenced, for exemple, in a tvOS front row app extension.